### PR TITLE
Add version flag

### DIFF
--- a/cmd/mcp-compose/main.go
+++ b/cmd/mcp-compose/main.go
@@ -7,8 +7,10 @@ import (
     "mcpcompose/internal/cmd"
 )
 
+var version = "dev"
+
 func main() {
-    rootCmd := cmd.NewRootCommand()
+    rootCmd := cmd.NewRootCommand(version)
     if err := rootCmd.Execute(); err != nil {
         fmt.Fprintf(os.Stderr, "Error: %s\n", err)
         os.Exit(1)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -6,11 +6,12 @@ import (
 )
 
 // in internal/cmd/root.go
-func NewRootCommand() *cobra.Command {
+func NewRootCommand(version string) *cobra.Command {
 	rootCmd := &cobra.Command{
-		Use:   "mcp-compose",
-		Short: "Manage MCP servers with compose",
-		Long:  `MCP-Compose is a tool for defining and running multi-server Model Context Protocol applications.`,
+		Use:     "mcp-compose",
+		Short:   "Manage MCP servers with compose",
+		Long:    `MCP-Compose is a tool for defining and running multi-server Model Context Protocol applications.`,
+		Version: version,
 	}
 
 	rootCmd.PersistentFlags().StringP("file", "c", "mcp-compose.yaml", "Specify compose file")


### PR DESCRIPTION
## Summary

Added `--version` flag support to mcp-compose CLI tool.

## Changes

- Added version variable in `cmd/mcp-compose/main.go` (defaults to "dev")
- Modified `NewRootCommand` function to accept version parameter
- Set Cobra command's `Version` field to enable `--version` flag functionality

## Testing

- Built and tested the binary: `./mcp-compose --version` outputs "mcp-compose version dev"
- Version can be set at build time using: `go build -ldflags "-X main.version=1.0.0"`

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update