### PR TITLE
Fix remaining Go 1.21 references in Dockerfiles

### DIFF
--- a/internal/cmd/proxy.go
+++ b/internal/cmd/proxy.go
@@ -345,7 +345,7 @@ func buildGoProxyImage(httpProxy bool) error {
 	fmt.Printf("Building Go proxy image (%s)...\n", imageName)
 
 	// Enhanced Dockerfile with protocol support
-	dockerfileContent := `FROM golang:1.21-alpine AS builder
+	dockerfileContent := `FROM golang:1.24-alpine AS builder
 WORKDIR /build
 
 # Install build dependencies

--- a/internal/memory/Dockerfile.memory-go
+++ b/internal/memory/Dockerfile.memory-go
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.21-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git gcc musl-dev ca-certificates


### PR DESCRIPTION
- Update dynamically generated Dockerfile in proxy.go from Go 1.21 to 1.24
- Update memory service Dockerfile from Go 1.21 to 1.24
- This fixes containerized proxy build errors due to Go version mismatch

🤖 Generated with [Claude Code](https://claude.ai/code)