### PR TITLE
Move embedded Dockerfiles to external files and update to Go 1.24

### DIFF
--- a/dockerfiles/Dockerfile.dashboard
+++ b/dockerfiles/Dockerfile.dashboard
@@ -1,0 +1,38 @@
+FROM golang:1.24-alpine AS builder
+WORKDIR /build
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+# Build the main mcp-compose binary
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -a -installsuffix cgo -o mcp-compose cmd/mcp-compose/main.go
+
+FROM alpine:latest
+# Install required packages including PostgreSQL client
+RUN apk --no-cache add ca-certificates docker-cli curl postgresql-client
+
+# Create non-root user
+RUN adduser -D -u 1000 dashboard
+WORKDIR /app
+COPY --from=builder /build/mcp-compose .
+
+# Change ownership to dashboard user
+RUN chown dashboard:dashboard /app/mcp-compose && chmod +x /app/mcp-compose
+
+EXPOSE 3001
+
+# Create a startup script with health checks
+RUN echo '#!/bin/sh' > /app/start.sh && \
+    echo 'echo "Dashboard container starting..."' >> /app/start.sh && \
+    echo 'echo "Environment variables:"' >> /app/start.sh && \
+    echo 'echo "  MCP_PROXY_URL: $MCP_PROXY_URL"' >> /app/start.sh && \
+    echo 'echo "  MCP_API_KEY: $MCP_API_KEY"' >> /app/start.sh && \
+    echo 'echo "  MCP_DASHBOARD_HOST: $MCP_DASHBOARD_HOST"' >> /app/start.sh && \
+    echo 'echo "  POSTGRES_URL: ${POSTGRES_URL:+configured}"' >> /app/start.sh && \
+    echo 'echo "Starting dashboard server on 0.0.0.0:3001..."' >> /app/start.sh && \
+    echo 'exec ./mcp-compose dashboard --native --file /app/mcp-compose.yaml --port 3001 --host 0.0.0.0' >> /app/start.sh && \
+    chmod +x /app/start.sh && \
+    chown dashboard:dashboard /app/start.sh
+
+# Switch to non-root user
+USER dashboard
+CMD ["/app/start.sh"]

--- a/dockerfiles/Dockerfile.memory-go
+++ b/dockerfiles/Dockerfile.memory-go
@@ -1,0 +1,61 @@
+# Build stage
+FROM golang:1.24-alpine AS builder
+
+# Install build dependencies
+RUN apk add --no-cache git gcc musl-dev ca-certificates
+
+# Set work directory  
+WORKDIR /build
+
+# Clone the new Go repository
+RUN git clone https://github.com/phildougherty/mcp-compose-memory.git .
+
+# Initialize go module and ensure all dependencies are resolved
+RUN go mod tidy
+
+# Download all dependencies
+RUN go mod download
+
+# Verify all dependencies are available
+RUN go list -m all
+
+# Build the application
+RUN CGO_ENABLED=1 GOOS=linux go build \
+    -a -installsuffix cgo \
+    -ldflags="-s -w" \
+    -o mcp-compose-memory \
+    .
+
+# Final stage
+FROM alpine:3.18
+
+# Install runtime dependencies  
+RUN apk --no-cache add ca-certificates tzdata postgresql-client wget
+
+# Set timezone
+ENV TZ=America/New_York
+
+# Set work directory
+WORKDIR /app
+
+# Copy binary from builder
+COPY --from=builder /build/mcp-compose-memory .
+
+# Make binary executable
+RUN chmod +x ./mcp-compose-memory
+
+# Create data directory with proper permissions
+RUN mkdir -p /data && chmod 755 /data
+
+# Default environment
+ENV DATABASE_URL=postgresql://postgres:password@postgres:5432/memory_graph?sslmode=disable
+
+# Expose the port
+EXPOSE 3001
+
+# Add health check
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 --start-period=15s \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:3001/health || exit 1
+
+# Run the server
+CMD ["./mcp-compose-memory", "--host", "0.0.0.0", "--port", "3001"]

--- a/dockerfiles/Dockerfile.proxy
+++ b/dockerfiles/Dockerfile.proxy
@@ -1,0 +1,50 @@
+FROM golang:1.24-alpine AS builder
+WORKDIR /build
+
+# Install build dependencies
+RUN apk add --no-cache git ca-certificates
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+# Build with enhanced protocol support
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -ldflags="-s -w" \
+    -a -installsuffix cgo \
+    -o mcp-compose-executable \
+    cmd/mcp-compose/main.go
+
+FROM alpine:latest
+
+# Add essential tools for proxy operation
+RUN apk --no-cache add \
+    ca-certificates \
+    docker-cli \
+    curl \
+    wget \
+    jq \
+    tzdata
+
+# Set timezone
+ENV TZ=UTC
+
+WORKDIR /app
+
+COPY --from=builder /build/mcp-compose-executable .
+
+# Create directories for various protocol features
+RUN mkdir -p /app/data /app/logs /app/cache /app/temp
+
+# Set proxy-specific environment variables
+ENV MCP_PROXY_PORT=9876
+ENV MCP_PROTOCOL_MODE=enhanced
+ENV MCP_ENABLE_NOTIFICATIONS=true
+ENV MCP_ENABLE_SUBSCRIPTIONS=true
+ENV MCP_ENABLE_PROGRESS=true
+ENV MCP_ENABLE_SAMPLING=true
+
+EXPOSE 9876
+
+CMD ["./mcp-compose-executable", "proxy", "--file", "/app/mcp-compose.yaml"]

--- a/dockerfiles/Dockerfile.task-scheduler
+++ b/dockerfiles/Dockerfile.task-scheduler
@@ -1,0 +1,58 @@
+# Build stage
+FROM golang:1.24-alpine AS builder
+
+# Install build dependencies
+RUN apk add --no-cache git gcc musl-dev ca-certificates
+
+# Set work directory
+WORKDIR /build
+
+# Clone the repository
+RUN git clone https://github.com/phildougherty/mcp-cron-persistent.git .
+
+# Download dependencies
+RUN go mod download
+
+# Build with proper flags and error handling
+RUN CGO_ENABLED=1 GOOS=linux go build \
+    -a -installsuffix cgo \
+    -ldflags="-s -w" \
+    -o mcp-cron \
+    ./cmd/mcp-cron
+
+# Final stage - use specific alpine version to avoid registry issues
+FROM alpine:3.18
+
+# Install runtime dependencies
+RUN apk --no-cache add ca-certificates tzdata curl sqlite
+
+# Set timezone
+ENV TZ=America/New_York
+RUN cp /usr/share/zoneinfo/America/New_York /etc/localtime && \
+    echo "America/New_York" > /etc/timezone
+
+# Set work directory
+WORKDIR /app
+
+# Copy binary from builder
+COPY --from=builder /build/mcp-cron .
+RUN chmod +x ./mcp-cron
+
+# Create data directory with proper permissions  
+RUN mkdir -p /data && chmod 755 /data
+
+# Default environment that will be overridden by container
+ENV MCP_CRON_DATABASE_PATH=/data/task-scheduler.db
+ENV MCP_CRON_SERVER_TRANSPORT=sse  
+ENV MCP_CRON_SERVER_ADDRESS=0.0.0.0
+ENV MCP_CRON_SERVER_PORT=8018
+
+# Expose the port (will be dynamically set)
+EXPOSE $MCP_CRON_SERVER_PORT
+
+# Add health check using environment variable
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 --start-period=15s \
+    CMD curl -f http://localhost:$MCP_CRON_SERVER_PORT/health || exit 1
+
+# Use exec form and environment variables for the command
+CMD ["sh", "-c", "./mcp-cron --transport=$MCP_CRON_SERVER_TRANSPORT --address=$MCP_CRON_SERVER_ADDRESS --port=$MCP_CRON_SERVER_PORT --db-path=$MCP_CRON_DATABASE_PATH"]

--- a/internal/cmd/task_scheduler.go
+++ b/internal/cmd/task_scheduler.go
@@ -652,75 +652,15 @@ func buildTaskSchedulerImageWithRetry(debug bool) error {
 }
 
 func buildTaskSchedulerImage(debug bool) error {
-	// Create Dockerfile with proper port handling
-	dockerfileContent := `# Build stage
-FROM golang:1.23-alpine AS builder
+	dockerfilePath := "dockerfiles/Dockerfile.task-scheduler"
+	
+	// Check if Dockerfile exists
+	if _, err := os.Stat(dockerfilePath); os.IsNotExist(err) {
 
-# Install build dependencies
-RUN apk add --no-cache git gcc musl-dev ca-certificates
-
-# Set work directory
-WORKDIR /build
-
-# Clone the repository
-RUN git clone https://github.com/phildougherty/mcp-cron-persistent.git .
-
-# Download dependencies
-RUN go mod download
-
-# Build with proper flags and error handling
-RUN CGO_ENABLED=1 GOOS=linux go build \
-    -a -installsuffix cgo \
-    -ldflags="-s -w" \
-    -o mcp-cron \
-    ./cmd/mcp-cron
-
-# Final stage - use specific alpine version to avoid registry issues
-FROM alpine:3.18
-
-# Install runtime dependencies
-RUN apk --no-cache add ca-certificates tzdata curl sqlite
-
-# Set timezone
-ENV TZ=America/New_York
-RUN cp /usr/share/zoneinfo/America/New_York /etc/localtime && \
-    echo "America/New_York" > /etc/timezone
-
-# Set work directory
-WORKDIR /app
-
-# Copy binary from builder
-COPY --from=builder /build/mcp-cron .
-RUN chmod +x ./mcp-cron
-
-# Create data directory with proper permissions  
-RUN mkdir -p /data && chmod 755 /data
-
-# Default environment that will be overridden by container
-ENV MCP_CRON_DATABASE_PATH=/data/task-scheduler.db
-ENV MCP_CRON_SERVER_TRANSPORT=sse  
-ENV MCP_CRON_SERVER_ADDRESS=0.0.0.0
-ENV MCP_CRON_SERVER_PORT=8018
-
-# Expose the port (will be dynamically set)
-EXPOSE $MCP_CRON_SERVER_PORT
-
-# Add health check using environment variable
-HEALTHCHECK --interval=30s --timeout=5s --retries=3 --start-period=15s \
-    CMD curl -f http://localhost:$MCP_CRON_SERVER_PORT/health || exit 1
-
-# Use exec form and environment variables for the command
-CMD ["sh", "-c", "./mcp-cron --transport=$MCP_CRON_SERVER_TRANSPORT --address=$MCP_CRON_SERVER_ADDRESS --port=$MCP_CRON_SERVER_PORT --db-path=$MCP_CRON_DATABASE_PATH"]
-`
-
-	dockerfileName := "Dockerfile.task-scheduler"
-	if err := os.WriteFile(dockerfileName, []byte(dockerfileContent), constants.DefaultFileMode); err != nil {
-
-		return fmt.Errorf("failed to write Dockerfile: %w", err)
+		return fmt.Errorf("Dockerfile not found at %s", dockerfilePath)
 	}
-	defer func() { _ = os.Remove(dockerfileName) }()
 
-	args := []string{"build", "-f", dockerfileName, "-t", "mcp-compose-task-scheduler:latest", "."}
+	args := []string{"build", "-f", dockerfilePath, "-t", "mcp-compose-task-scheduler:latest", "."}
 	if debug {
 		args = append(args, "--progress=plain", "--no-cache")
 	}

--- a/internal/dashboard/manager.go
+++ b/internal/dashboard/manager.go
@@ -2,9 +2,7 @@ package dashboard
 
 import (
 	"fmt"
-	"log"
 	"mcpcompose/internal/config"
-	"mcpcompose/internal/constants"
 	"mcpcompose/internal/container"
 	"mcpcompose/internal/logging"
 	"os"
@@ -95,57 +93,13 @@ func (m *Manager) Stop() error {
 func (m *Manager) buildDashboardImage() error {
 	m.logger.Info("Building dashboard Docker image...")
 
-	// Enhanced Dockerfile with PostgreSQL dependencies
-	dockerfileContent := `FROM golang:1.21-alpine AS builder
-WORKDIR /build
-COPY go.mod go.sum ./
-RUN go mod download
-COPY . .
-# Build the main mcp-compose binary
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -a -installsuffix cgo -o mcp-compose cmd/mcp-compose/main.go
+	dockerfilePath := "dockerfiles/Dockerfile.dashboard"
+	
+	// Check if Dockerfile exists
+	if _, err := os.Stat(dockerfilePath); os.IsNotExist(err) {
 
-FROM alpine:latest
-# Install required packages including PostgreSQL client
-RUN apk --no-cache add ca-certificates docker-cli curl postgresql-client
-
-# Create non-root user
-RUN adduser -D -u 1000 dashboard
-WORKDIR /app
-COPY --from=builder /build/mcp-compose .
-
-# Change ownership to dashboard user
-RUN chown dashboard:dashboard /app/mcp-compose && chmod +x /app/mcp-compose
-
-EXPOSE 3001
-
-# Create a startup script with health checks
-RUN echo '#!/bin/sh' > /app/start.sh && \
-    echo 'echo "Dashboard container starting..."' >> /app/start.sh && \
-    echo 'echo "Environment variables:"' >> /app/start.sh && \
-    echo 'echo "  MCP_PROXY_URL: $MCP_PROXY_URL"' >> /app/start.sh && \
-    echo 'echo "  MCP_API_KEY: $MCP_API_KEY"' >> /app/start.sh && \
-    echo 'echo "  MCP_DASHBOARD_HOST: $MCP_DASHBOARD_HOST"' >> /app/start.sh && \
-    echo 'echo "  POSTGRES_URL: ${POSTGRES_URL:+configured}"' >> /app/start.sh && \
-    echo 'echo "Starting dashboard server on 0.0.0.0:3001..."' >> /app/start.sh && \
-    echo 'exec ./mcp-compose dashboard --native --file /app/mcp-compose.yaml --port 3001 --host 0.0.0.0' >> /app/start.sh && \
-    chmod +x /app/start.sh && \
-    chown dashboard:dashboard /app/start.sh
-
-# Switch to non-root user
-USER dashboard
-CMD ["/app/start.sh"]
-`
-
-	dockerfilePath := "Dockerfile.dashboard"
-	if err := os.WriteFile(dockerfilePath, []byte(dockerfileContent), constants.DefaultFileMode); err != nil {
-
-		return fmt.Errorf("failed to write Dockerfile: %w", err)
+		return fmt.Errorf("Dockerfile not found at %s", dockerfilePath)
 	}
-	defer func() {
-		if err := os.Remove(dockerfilePath); err != nil {
-			log.Printf("Warning: failed to remove dockerfile: %v", err)
-		}
-	}()
 
 	// Build the image
 	cmd := exec.Command("docker", "build", "-f", dockerfilePath, "-t", "mcp-compose-dashboard:latest", ".")


### PR DESCRIPTION
- Extract embedded Dockerfiles from Go code to dockerfiles/ directory
- Update all Dockerfiles to use golang:1.24-alpine instead of 1.21/1.23
- Refactor dashboard, memory, task-scheduler, and proxy managers to read from filesystem
- Remove unused imports and variables
- Clean up temporary Dockerfile creation logic

Benefits:
- Easier maintenance and version updates
- Better separation of concerns
- More consistent with standard practices
- Enables easier customization of build process

🤖 Generated with [Claude Code](https://claude.ai/code)