### PR TITLE
Fix memory analytics showing zero entities and relationships

### DIFF
--- a/internal/dashboard/templates/static/components/memory.js
+++ b/internal/dashboard/templates/static/components/memory.js
@@ -308,11 +308,14 @@ const MemoryViewer = {
         
         // Data loading methods
         async loadAllData() {
+            // Load entities and relations first
             await Promise.all([
                 this.loadEntities(),
-                this.loadRelations(),
-                this.loadStats()
+                this.loadRelations()
             ]);
+            
+            // Then calculate statistics from the loaded data
+            await this.loadStats();
         },
         
         async loadEntities() {


### PR DESCRIPTION
- Fixed race condition in memory.js where statistics were calculated before entities and relations were loaded from the server
- Changed loadAllData() to load entities/relations first, then calculate stats
- Memory analytics now correctly show total entities and relationships
- Browse tab was already working, analytics tab now shows correct data

The issue was that loadStats() was called in parallel with loadEntities(), causing statistics to be calculated from empty arrays before data was loaded.

🤖 Generated with [Claude Code](https://claude.ai/code)