### PR TITLE
Fix dashboard health checks by implementing proactive HTTP connection…

### DIFF
--- a/internal/dashboard/templates/static/components/dashboard.js
+++ b/internal/dashboard/templates/static/components/dashboard.js
@@ -382,10 +382,15 @@ const DashboardApp = {
         },
         
         isServerHealthy(server) {
-            // A server is healthy if both:
-            // 1. Container is running
-            // 2. Proxy connection is established and healthy
-            return this.isContainerRunning(server) && this.getConnectionStatus(server) === 'Connected';
+            // A server is healthy if the proxy connection is established and healthy
+            // This is the primary indicator of MCP server health
+            const connectionStatus = this.getConnectionStatus(server);
+            if (connectionStatus === 'Connected') {
+                return true;
+            }
+            
+            // Fallback: if no HTTP connection but container is running, it might be a STDIO server
+            return this.isContainerRunning(server) && server.configProtocol !== 'http';
         },
         
         getHttpConnection(server) {

--- a/internal/server/api_handlers.go
+++ b/internal/server/api_handlers.go
@@ -250,6 +250,12 @@ func (h *ProxyHandler) handleDiscoveryEndpoint(w http.ResponseWriter, r *http.Re
 }
 
 func (h *ProxyHandler) handleConnectionsAPI(w http.ResponseWriter, _ *http.Request) {
+	// Ensure HTTP connections are established before returning status
+	h.ensureHTTPConnectionsEstablished()
+	
+	// Give connections a moment to be established
+	time.Sleep(100 * time.Millisecond)
+	
 	h.ConnectionMutex.RLock()
 	connectionsSnapshot := make(map[string]interface{})
 	for name, conn := range h.ServerConnections {

--- a/internal/server/proxy_handler.go
+++ b/internal/server/proxy_handler.go
@@ -172,6 +172,9 @@ func NewProxyHandler(mgr *Manager, configFile, apiKey string) *ProxyHandler {
 	// Start connection monitoring
 	handler.connectionManager.StartMonitoring(constants.MonitoringInterval)
 
+	// Establish initial HTTP connections to all configured HTTP servers
+	go handler.establishInitialHTTPConnections()
+
 
 	return handler
 }


### PR DESCRIPTION
… establishment

- Add establishInitialHTTPConnections() to create connections when proxy starts
- Add ensureHTTPConnectionsEstablished() for on-demand connection creation
- Modify /api/connections endpoint to establish connections before returning status
- Update dashboard health logic to prioritize HTTP connection status over container status
- Resolve issue where servers showed as unhealthy despite running containers

🤖 Generated with [Claude Code](https://claude.ai/code)