### PR TITLE
Fix dashboard logs section proxy streaming and null data handling

### DIFF
--- a/internal/dashboard/templates/static/components/logs.js
+++ b/internal/dashboard/templates/static/components/logs.js
@@ -43,14 +43,19 @@ const LogViewer = {
                     throw new Error(`HTTP ${response.status}: ${response.statusText}`);
                 }
                 const data = await response.json();
-                this.logs = data.logs.map((line, index) => ({
-                    id: index,
-                    timestamp: new Date().toISOString(),
-                    server: this.selectedServer,
-                    level: this.detectLogLevel(line),
-                    message: line,
-                    raw: line
-                }));
+                if (data.logs && Array.isArray(data.logs)) {
+                    this.logs = data.logs.map((line, index) => ({
+                        id: index,
+                        timestamp: new Date().toISOString(),
+                        server: this.selectedServer,
+                        level: this.detectLogLevel(line),
+                        message: line,
+                        raw: line
+                    }));
+                } else {
+                    this.logs = [];
+                    console.warn('No logs data received or logs is not an array:', data);
+                }
                 this.scrollToBottom();
                 this.showToast('Logs loaded successfully', 'success');
             } catch (err) {


### PR DESCRIPTION
- Fix dropdown initialization issue by adding null check for data.logs array
- Fix WebSocket streaming to use proxy endpoints instead of direct docker socket
- WebSocket handler now calls /api/containers/{name}/logs?follow=true via proxy first
- Fallback to direct docker command only if proxy fails
- Eliminates "Cannot read properties of null (reading 'map')" error
- Resolves docker socket permission denied errors during streaming

🤖 Generated with [Claude Code](https://claude.ai/code)